### PR TITLE
Add Python type hints using PEP 561 stubs

### DIFF
--- a/python/syntax_checker/__init__.pyi
+++ b/python/syntax_checker/__init__.pyi
@@ -3,9 +3,27 @@ from typing_extensions import Literal, TypeAlias
 
 # Type alias for supported file extensions
 FileExtension: TypeAlias = Literal[
-    "py", "js", "ts", "tsx", "jsx", "rs", "c", "h", "cpp", 
-    "hpp", "sh", "css", "html", "htm", "java", "json", "go", 
-    "rb", "toml", "php", "cs"
+    "py",     # Python parser
+    "js",     # JavaScript parser
+    "ts",     # TypeScript parser
+    "tsx",    # TypeScript parser
+    "jsx",    # JavaScript parser
+    "rs",     # Rust parser
+    "c",      # C parser
+    "h",      # C parser
+    "cpp",    # C++ parser
+    "hpp",    # C++ parser
+    "sh",     # Bash parser
+    "css",    # CSS parser
+    "html",   # HTML parser
+    "htm",    # HTML parser
+    "java",   # Java parser
+    "json",   # JSON parser
+    "go",     # Go parser
+    "rb",     # Ruby parser
+    "toml",   # TOML parser
+    "php",    # PHP parser
+    "cs"      # C# parser
 ]
 
 class Output:

--- a/python/syntax_checker/__init__.pyi
+++ b/python/syntax_checker/__init__.pyi
@@ -1,0 +1,33 @@
+from typing import List, Tuple, Union
+from typing_extensions import Literal, TypeAlias
+
+# Type alias for supported file extensions
+FileExtension: TypeAlias = Literal[
+    "py", "js", "ts", "tsx", "jsx", "rs", "c", "h", "cpp", 
+    "hpp", "sh", "css", "html", "htm", "java", "json", "go", 
+    "rb", "toml", "php", "cs"
+]
+
+class Output:
+    errors: List[Tuple[int, int]]  # [(line, column), ...] for each error
+    description: str  # Detailed error descriptions
+    
+    def __init__(self) -> None: ...
+
+def check_syntax(program_extension: Union[str, FileExtension], program_content: str) -> Output:
+    """Check syntax of source code using tree-sitter parsers.
+
+    Args:
+        program_extension: File extension to determine the parser (e.g. 'py', 'js')
+        program_content: Source code to check
+
+    Returns:
+        Output object containing:
+            - errors: List of (line, column) positions where errors were found
+            - description: Detailed description of each error
+
+    Raises:
+        ValueError: If program_extension is not supported
+        RuntimeError: If parser fails to load or parse the content
+    """
+    ...


### PR DESCRIPTION
This PR adds Python type hints following PEP 561:

* Add type stubs for Output class and check_syntax function
* Add py.typed marker for PEP 561 compliance
* Configure maturin to include Python package
* Add comprehensive typing for file extensions and error types

Tested with mypy --strict and confirmed working.

The type hints provide:
- Full typing for Output class including error tuples
- Comprehensive FileExtension type alias for all supported file types
- Complete function signature for check_syntax with all exceptions documented