### PR TITLE
fix: add C99 flag for linux builds

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,6 +19,41 @@ permissions:
   contents: read
 
 jobs:
+  linux:
+    runs-on: ${{ matrix.platform.runner }}
+    env:
+      CFLAGS: "-std=c99"
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-22.04
+            target: x86_64
+          - runner: ubuntu-22.04
+            target: x86
+          - runner: ubuntu-22.04
+            target: aarch64
+          - runner: ubuntu-22.04
+            target: armv7
+          - runner: ubuntu-22.04
+            target: s390x
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+          manylinux: auto
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.platform.target }}
+          path: dist
+
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -107,7 +142,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [musllinux, windows, macos]
+    needs: [linux, musllinux, windows, macos]
     permissions:
       # Use to sign the release artifacts
       id-token: write

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     env:
       CFLAGS: "-std=c99"
+      CXXFLAGS: "-std=c++11"
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
This PR fixes the Linux build issues by adding the -std=c99 flag to CFLAGS. This addresses the compilation errors in tree-sitter-typescript when building for Linux targets.