### PR TITLE
Remove linux build job and add pyproject.toml

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,43 +19,6 @@ permissions:
   contents: read
 
 jobs:
-  linux:
-    runs-on: ${{ matrix.platform.runner }}
-    env:
-      CFLAGS: "-std=c99"
-      CXXFLAGS: "-std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1"
-      CPPFLAGS: "-D_GLIBCXX_USE_CXX11_ABI=1"
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-22.04
-            target: x86_64
-          - runner: ubuntu-22.04
-            target: x86
-          - runner: ubuntu-22.04
-            target: aarch64
-          - runner: ubuntu-22.04
-            target: armv7
-          - runner: ubuntu-22.04
-            target: s390x
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: 'true'
-          manylinux: auto
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-linux-${{ matrix.platform.target }}
-          path: dist
-
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -144,7 +107,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [linux, musllinux, windows, macos]
+    needs: [musllinux, windows, macos]
     permissions:
       # Use to sign the release artifacts
       id-token: write

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntax-checker"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 description = "Multi-language syntax checker using tree-sitter parsers with Python bindings"
 homepage = "https://github.com/rusiaaman/syntax-checker"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "syntax-checker"
 description = "A syntax checker for multiple languages using tree-sitter"
 authors = [
-    {name = "Aaman Rusia", email = "aaman@rusia.co.in"}
+    {name = "Aman Rusia", email = "gapypi@arcfu.com"}
 ]
 requires-python = ">=3.7"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["maturin>=1.4,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "syntax-checker"
+description = "A syntax checker for multiple languages using tree-sitter"
+authors = [
+    {name = "Aaman Rusia", email = "aaman@rusia.co.in"}
+]
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Rust",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Text Processing :: General",
+]
+
+[tool.maturin]
+python-source = "python"
+features = ["pyo3/extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,4 @@ classifiers = [
 ]
 
 [tool.maturin]
-python-source = "python"
 features = ["pyo3/extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ authors = [
     {name = "Aman Rusia", email = "gapypi@arcfu.com"}
 ]
 requires-python = ">=3.7"
+homepage = "https://github.com/rusiaaman/syntax-checker"
+repository = "https://github.com/rusiaaman/syntax-checker"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
This PR removes the linux build job from the GitHub Actions workflow and adds a pyproject.toml file for maturin configuration.